### PR TITLE
Update localhost instructions.

### DIFF
--- a/1-windows-oss-terminal-wsl/README.md
+++ b/1-windows-oss-terminal-wsl/README.md
@@ -111,11 +111,9 @@ Run our application with `go run`
 go run main.go
 ```
 
-Use a web browser to open <http://wsl.local> to see the site is working. You are now running the Linux version of Go locally on Windows via WSL. 
+Use a web browser to open <http://localhost:8080> to see the site is working. You are now running the Linux version of Go locally on Windows via WSL. 
 
 If you are running `go run main.go` inside tmux, mentioned above, you can open another pane and run `curl localhost:8080/echo` or [hey](https://github.com/rakyll/hey) via `hey http://localhost:8080/echo' to send some load to our application.
-
-**Note:** This preview version of WSL 2 requires obtaining the ip address of the WSL 2 distro in order to browse a web site hosted in WSL 2. We have made localhost available via `wsl.local` using [go-wsl2-host](https://github.com/shayne/go-wsl2-host) (see: [REQUIREMENTS.md](REQUIREMENTS.md)). But, if you have not installed this, you can find your WSL2_IP_ADDRESS by running the following in the Ubuntu shell: `ifconfig | grep inet | awk 'FNR==1{print $2}'`
 
 ## Debug a Go project with VS Code
 

--- a/1-windows-oss-terminal-wsl/REQUIREMENTS.md
+++ b/1-windows-oss-terminal-wsl/REQUIREMENTS.md
@@ -14,12 +14,6 @@
 - In Ubuntu shell install utilities `sudo apt install cmatrix caca-utils htop`
 - `Ubuntu Mono` font from <https://fonts.google.com/specimen/Ubuntu+Mono>
 
-## Windows Subsystem for Linux (WSL) 2
-
-For WSL 2 we will install [go-wsl2-host](https://github.com/shayne/go-wsl2-host) so we can open wsl.local.
-
-You may need to run `services.msc` to ensure the service is starting and able to logon as a service with the user you have chosen. Afterwards, you can `cat C:\windows\System32\drivers\etc\hosts` to confirm the hosts entry has been added.
-
 ## Cleanup
 - Close all running Terminal or Code windows
 - Delete terminal profile file (see: [CLEANUP.sh](CLEANUP.sh)): 


### PR DESCRIPTION
WSL2 now allows "listening tcp sockets in WSL2 to be accessible from the host by using localhost:port" as of build 18945 (https://github.com/MicrosoftDocs/WSL/blob/live/WSL/release-notes.md#build-18945 )